### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-  - "lts/*"
+  - "node"
+  - "10"
   - "8"
+  - "6"


### PR DESCRIPTION
`lts/*` tests only Node.js 10 (the latest LTS branch) but not 6 and 8. We should test on 6, 8 and 10 and also stable (11, fail early).