### PR TITLE
Allow selector to be a function so we can render in a detached dom

### DIFF
--- a/src/views/autoCompleteView.js
+++ b/src/views/autoCompleteView.js
@@ -1,7 +1,7 @@
 let resultsList;
 
 // Gets the user's input value
-const getInput = selector => document.querySelector(selector);
+const getInput = selector => typeof selector === 'string' ? document.querySelector(selector) : selector();
 
 // Creats the results list HTML tag
 const createResultsList = renderResults => {


### PR DESCRIPTION
It's pretty common to need to create components that are attached to elements not yet in the page's DOM (document.query wont work). Here's an example:

```
        this.ele = document.createElement('div');
        this.ele.innerHTML = template;

        new autoComplete({
            data: {
                src: this.cmds,
                key: 'cmdName'
            },
            selector: () => this.ele.querySelector('#desiredOutput'),
            highlight: true,
            onSelection: () => {

            }
        });
```