### PR TITLE
If there is an error, then it should be shown using console.error. I

### DIFF
--- a/src/models/autoComplete.js
+++ b/src/models/autoComplete.js
@@ -139,21 +139,16 @@ export default class autoComplete {
 
 	// Starts the app Enigne
 	init() {
-		try {
-			// Data Source holder
-			const dataSrc = this.data.src();
-			// Data source is Async
-			if (dataSrc instanceof Promise) {
-				// Return Data
-				dataSrc.then(data => this.ignite(data));
-				// Data source is Array/Function
-			} else {
-				// Return Data
-				this.ignite(dataSrc);
-			}
-		} catch (error) {
-			// Error in Engine failure
-			autoCompleteView.error(error);
+		// Data Source holder
+		const dataSrc = this.data.src();
+		// Data source is Async
+		if (dataSrc instanceof Promise) {
+			// Return Data
+			dataSrc.then(data => this.ignite(data));
+			// Data source is Array/Function
+		} else {
+			// Return Data
+			this.ignite(dataSrc);
 		}
 	}
 }

--- a/src/views/autoCompleteView.js
+++ b/src/views/autoCompleteView.js
@@ -54,11 +54,6 @@ const getSelection = (field, callback, resultsValues, dataKey) => {
 	});
 };
 
-// Error message render to UI
-const error = error => {
-	document.querySelector("body").innerHTML = `<div class="autoComplete_error">${error}</div>`;
-};
-
 export const autoCompleteView = {
 	getInput,
 	createResultsList,
@@ -66,5 +61,4 @@ export const autoCompleteView = {
 	addResultsToList,
 	getSelection,
 	clearResults,
-	error
 };


### PR DESCRIPTION
can't think of an error that would be helpful or should be shown to the
end users on an autocomplete that doesn't have any server-side code. Any
recoverable errors should fail silently for users, loudly for developers IMO.