### PR TITLE
HOTFIX: Keep the same border size when overing

### DIFF
--- a/dist/css/autoComplete.css
+++ b/dist/css/autoComplete.css
@@ -112,19 +112,19 @@
 .autoComplete_result:hover {
     cursor: pointer;
     background-color: rgba(255, 248, 248, 0.9);
-    border-left: 2px solid rgba(255, 122, 122, 1);
-    border-right: 2px solid rgba(255, 122, 122, 1);
-    border-top: 2px solid transparent;
-    border-bottom: 2px solid transparent;
+    border-left-color: rgba(255, 122, 122, 1);
+    border-right-color: rgba(255, 122, 122, 1);
+    border-top-color: transparent;
+    border-bottom-color: transparent;
 }
 
 .autoComplete_result:focus {
     outline: none;
     background-color: rgba(255, 248, 248, 0.9);
-    border-left: 2px solid rgba(255, 122, 122, 1);
-    border-right: 2px solid rgba(255, 122, 122, 1);
-    border-top: 2px solid transparent;
-    border-bottom: 2px solid transparent;
+    border-left-color: rgba(255, 122, 122, 1);
+    border-right-color: rgba(255, 122, 122, 1);
+    border-top-color: transparent;
+    border-bottom-color: transparent;
 }
 
 .autoComplete_highlighted {


### PR DESCRIPTION
Just a small improvement in the showcase. I don't know if that was intended, but when hovering the result items, the border seemed to change in size and therefore "displacing" elements.

If that's intended, ignore this :)

Great library btw!