### PR TITLE
target only the designated selector

### DIFF
--- a/src/views/autoCompleteView.js
+++ b/src/views/autoCompleteView.js
@@ -71,6 +71,7 @@ const navigation = (selector, resultsList) => {
   const input = getInput(selector);
   const first = resultsList.firstChild;
   document.onkeydown = event => {
+    if (!event.target.matches(selector)) return;
     const active = document.activeElement;
     switch (event.keyCode) {
       // Arrow Up


### PR DESCRIPTION

![demo](https://user-images.githubusercontent.com/1922591/59871866-80e5c580-9366-11e9-8e97-a95931e381a8.png)

(Note: These are minor errors. They do not stop the page from working. Everything still works as intended. Thank you for this useful and lightweight library.)

This pull request fixes TypeErrors that appear when using Arrow Down and Arrow Up keys.

- In Firefox, "TypeError: active.nextSibling is null."
- In Chrome: "Uncaught TypeError: Cannot read property 'focus' of null at HTMLDocument.document.onkeydown."

To reproduce the error on your Demo page:
1. Enter any food. For example, type "Pi" and select Pina Colada.
2. Then, anywhere on the page, use the Down arrow.

The errors are more pronounced when used on a page with multiple select fields. 

