### PR TITLE
Add bug & feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+labels: bug
+about: Something broke or is not functioning as expected.
+
+---
+
+<!-- 🚨🚨🚨 READ THIS FIRST 🚨🚨🚨 -->
+<!--
+  In order to help solve issues quickly, we need you to make a best effort to complete the information below. Any incomplete bug reports will be closed.
+-->
+
+- [ ] **System Information**
+  - [ ] Browser type and version
+  - [ ] OS type and version
+  - [ ] WINDOWS: be sure to indicate which terminal you're using -- (i.e., cmd.exe, powershell, git- bash, cygwin, Ubuntu via windows subsystem for linux, etc...)
+  - [ ] Node version (IF applicable)
+    - [ ] Any error messages that may be in the console where you ran npm start
+  - [ ] Any error messages in the JS console
+
+- [ ] **Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+- [ ] **To Reproduce**
+Steps to reproduce the behavior: <!-- Example below-!>
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error ..
+
+- [ ] **Expected behavior**
+A clear and concise description of what you expected to happen.
+
+- [ ] **Screenshots or GIF's (optional, but HIGHLT RECOMMENDED)**
+If applicable, add screenshots to help explain your problem.
+
+- [ ] **Additional context (optional)**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+labels: enhancement
+about: Suggest an idea (or improvement for an existing feature) for this project
+
+---
+<!-- 🚨🚨🚨 READ THIS FIRST 🚨🚨🚨 -->
+<!--
+  Please make sure your feature request hasn't already been suggested.
+  1. To check go to `https://github.com/TarekRaafat/autoComplete.js/issues`
+  2. Search the issues and see if matches show for your request idea.
+    - If someone else has already created something similar and you'd like to give feedback, add a comment to that issue.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Thoroughly Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Please provide a few use cases for this feature**
+1. ....
+2. ...
+
+**Please Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
**What is the change?**
- Add issue templates

**Why are we making this change?**
- By adding [issue templates](https://help.github.com/en/articles/creating-issue-templates-for-your-repository) (a native github feature), we can prompt contributors to answer a few questions before submitting an issue.

When a user clicks `new issue` they will be prompted to choose which type of issue it is:
![Screen Shot 2019-08-13 at 11 55 35 PM](https://user-images.githubusercontent.com/6743796/63000398-e796d500-be25-11e9-9f17-df8fccfdec4c.png)

After choosing the type of issue, they will be shown a template inside the issues text area editor:

![Screen Shot 2019-08-13 at 11 56 54 PM](https://user-images.githubusercontent.com/6743796/63000485-2462cc00-be26-11e9-8103-107cb02b5796.png)




