### PR TITLE
Fix result item selection error if a descendant element is clicked

### DIFF
--- a/src/views/autoCompleteView.js
+++ b/src/views/autoCompleteView.js
@@ -99,7 +99,7 @@ const onSelection = (event, field, resultsList, feedback, resultsValues, selecti
       if (event.keyCode === keys.ENTER) {
         return value.index === Number(selection.getAttribute(dataAttribute));
       } else if (event.type === "mousedown") {
-        return value.index === Number(event.target.getAttribute(dataAttribute));
+        return value.index === Number(event.currentTarget.getAttribute(dataAttribute));
       }
     }),
   });


### PR DESCRIPTION
It you click on a <span> (or any descendant element) in a li.autoComplete_result, `Number(event.target.getAttribute(dataAttribute))` will always return 0 because event.target will be the span, not the li. This fixes that problem.

(You can even see this happens on https://tarekraafat.github.io/autoComplete.js/demo/ if you click on the highlighted portion of a result item)