### PR TITLE
Adds mention of the custom autoComplete event to the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -179,6 +179,8 @@ new autoComplete({
     searchEngine: "strict",			  // Search Engine type/mode 		  | (Optional)
     resultsList: {					   // Rendered results list object 	 | (Optional)
         render: true,
+        /* if set to false, add an eventListener to the selector for event type
+           "autoComplete" to handle the result */
 		container: source => {
 			source.setAttribute("id", "food_list");
 		},


### PR DESCRIPTION
I had a hard time figuring out how to use autoComplete.js without the resultList.render API (`render: false`). This PR adds mention of `autoComplete` event that is dispatched to the selector. I don't think that's mentioned anywhere outside of the source code.