### PR TITLE
Implement a "more results" in search results

### DIFF
--- a/src/models/autoComplete.js
+++ b/src/models/autoComplete.js
@@ -29,8 +29,8 @@ export default class autoComplete {
       sort = false, // Sorting results list
       placeHolder, // Placeholder text
       maxResults = 5, // Maximum number of results to show
-      resultsPerPage = 5,
-      loadMoreResults = false,
+      resultsPerPage = 5, // The number of results to show per page
+      loadMoreResults = false, // Whether to enable "More Results" button
       resultItem: {
         content = false, // Result item function
         element: resultItemElement = "li", // Result item element tag
@@ -202,6 +202,22 @@ export default class autoComplete {
         list,
       });
     });
+  }
+
+  /**
+   * Push resultsPerPage more results 
+   * @param data The array of objects for all the results, including those not currently loaded
+   */
+  loadMoreResults(data) {
+    // How do I get the currently displayed list
+
+    for (let index = resList.length; i < resList.length + this.resultsPerPage; i++) {
+      data.push({
+        index,
+        match,
+        value: resList[index]
+      });
+    }
   }
 
   /**

--- a/src/models/autoComplete.js
+++ b/src/models/autoComplete.js
@@ -29,6 +29,8 @@ export default class autoComplete {
       sort = false, // Sorting results list
       placeHolder, // Placeholder text
       maxResults = 5, // Maximum number of results to show
+      resultsPerPage = 5,
+      loadMoreResults = false,
       resultItem: {
         content = false, // Result item function
         element: resultItemElement = "li", // Result item element tag
@@ -71,6 +73,8 @@ export default class autoComplete {
     this.sort = sort;
     this.placeHolder = placeHolder;
     this.maxResults = maxResults;
+    this.resultsPerPage = resultsPerPage;
+    this.loadMoreResults = loadMoreResults;
     this.resultItem = {
       content,
       element: resultItemElement,
@@ -189,12 +193,12 @@ export default class autoComplete {
         }
       });
       // Sorting / Slicing final results list
-      const list = this.sort
-        ? resList.sort(this.sort).slice(0, this.maxResults)
-        : resList.slice(0, this.maxResults);
+      const fullList = this.sort ? resList.sort(this.sort) : resList;
+      const list = fullList.slice(0, this.maxResults);
       // Returns rendered list
       return resolve({
         matches: resList.length,
+        fullList,
         list,
       });
     });


### PR DESCRIPTION
This pull request implements a "more results" function, including a button, in which the developer can specify a resultsPerPage property that shows a certain number of results between every time the user clicks "More Results". It also uses other properties, including the "loadMoreResults" boolean in case the developer wants to stick to the original functionality. 

Closes #95 