### PR TITLE
allow node installations newer than 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "rollup-plugin-uglify": "^6.0.4"
   },
   "engines": {
-    "node": "12",
+    "node": ">=12",
     "npm": "6"
   }
 }


### PR DESCRIPTION
Hello,

Currently you can't install this package if you're using node v13, v14, v15.

```bash
yarn add -D @tarekraafat/autocomplete.js
```
Gives
```
error @tarekraafat/autocomplete.js@8.2.0: The engine "node" is incompatible with this module. Expected version "12". Got "15.5.0"
```