### PR TITLE
Provide the event consumer more information about the event

### DIFF
--- a/src/controllers/listController.js
+++ b/src/controllers/listController.js
@@ -43,11 +43,12 @@ const generateList = (config, data, matches) => {
     // create result item
     const resultItem = createItem(item, index, config);
     // Listen to clicks on this item
-    resultItem.addEventListener("click", () => {
+    resultItem.addEventListener("click", (e) => {
       // Prepare onSelection feedback data object
       const dataFeedback = {
         matches,
         input: data.input,
+        event: e,
         query: data.query,
         results: data.results,
         selection: {


### PR DESCRIPTION
Providing the `event` object to the event consumer will make the user have more flexibility.
ex. I use the `event` object to get whether the end user has pressed `shift` keyboard key when he choose an entry, this way I can decide whether to open the selection to a new tab or to navigate current page.
```javascript
onSelection: feedback => {
  if (feedback.event.shiftKey) {
    window.open(url);
  }else {
    window.location.href = url;
  }
}
```