### PR TITLE
Remove previous keydown listener

### DIFF
--- a/src/controllers/navigationController.js
+++ b/src/controllers/navigationController.js
@@ -116,6 +116,11 @@ const navigate = (config, dataFeedback) => {
   };
 
   const navigate = config.resultsList.navigation || navigation;
+
+  // Remove previous keydown listener
+  if (config.inputField.autoCompleteNavigate) config.inputField.removeEventListener("keydown", config.inputField.autoCompleteNavigate)
+  config.inputField.autoCompleteNavigate = navigate
+
   /**
    * @listens {keydown} Listens to all `keydown` events on the input field
    **/


### PR DESCRIPTION
This PR fixes a bug when selecting items using the keyboard.

## Bug

To replicate the bug on the demo app of the current release:

- Write "Food"
- Press ArrowDown on the keyboard three times to land on "Food Colouring - Red"
- Erase one character to be left with "Foo" (this resets the navigation)
- Press Tab to lend on the first item "Food Colouring - Green"
- Press Enter to select the entry
- Bug: the fourth item, "Black-footed ferret", is selected instead

## Explanation

The navigation controller does not remove the previously set `navigate` keydown listener after the reset. On keydown, only the first listener added updates its `currentFocus` or selects the item. This causes the navigation to use the wrong index on selection with the keyboard after the list is reset.

## Fix

Remove previous keydown listener on navigation init.

## Notes

I wasn't sure how to reference the previous handler function. I attached it to the `inputField` under a rather descriptive property.