### PR TITLE
Fix "TypeError: "query" is read-only" in dataController.js

### DIFF
--- a/src/controllers/dataController.js
+++ b/src/controllers/dataController.js
@@ -7,7 +7,7 @@ import search from "./searchController";
  * @param {Object} ctx - autoComplete.js context
  */
 const getData = async (ctx) => {
-  const { input, query, data } = ctx;
+  let { input, query, data } = ctx;
 
   if (data.cache && data.store) return;
 


### PR DESCRIPTION
As a `const` cannot be redefined, and `query` is redefined a few lines further, we were getting a `TypeError: "query" is read-only` error in `dataController.js`. 

This patch switches it to a `let` and the error is gone.

Version used: 10.0.4