### PR TITLE
Fix mark tag's invalid "classes" to "class" attribute

### DIFF
--- a/dist/autoComplete.js
+++ b/dist/autoComplete.js
@@ -245,11 +245,11 @@
   var checkTrigger = function checkTrigger(query, condition, threshold) {
     return condition ? condition(query) : query.length >= threshold;
   };
-  var mark = function mark(value, classes) {
+  var mark = function mark(value, klass) {
     return create("mark", _objectSpread2({
       innerHTML: value
-    }, typeof classes === "string" && {
-      classes: classes
+    }, typeof klass === "string" && {
+      class: klass
     })).outerHTML;
   };
 

--- a/docs/demo/js/autoComplete.js
+++ b/docs/demo/js/autoComplete.js
@@ -245,11 +245,11 @@
   var checkTrigger = function checkTrigger(query, condition, threshold) {
     return condition ? condition(query) : query.length >= threshold;
   };
-  var mark = function mark(value, classes) {
+  var mark = function mark(value, klass) {
     return create("mark", _objectSpread2({
       innerHTML: value
-    }, typeof classes === "string" && {
-      classes: classes
+    }, typeof klass === "string" && {
+      class: klass
     })).outerHTML;
   };
 

--- a/src/helpers/io.js
+++ b/src/helpers/io.js
@@ -105,14 +105,14 @@ const checkTrigger = (query, condition, threshold) => (condition ? condition(que
  * Highlight matching characters
  *
  * @param {String} value - user's raw search query value
- * @param {Array} classes - of highlighted character
+ * @param {String} klass - of highlighted character
  *
  * @returns {HTMLElement} - newly create html element
  */
-const mark = (value, classes) =>
+const mark = (value, klass) =>
   create("mark", {
     innerHTML: value,
-    ...(typeof classes === "string" && { classes }),
+    ...(typeof klass === "string" && { class: klass }),
   }).outerHTML;
 
 export { select, create, getQuery, format, debounce, checkTrigger, mark };


### PR DESCRIPTION
The following config produces invalid <mark> tag's attribute:

```javascript
resultItem: {
  highlight: "autoComplete_highlighted",
}
```

Fix invalid attribute of <mark> tag:

```diff
- <mark classes="autoComplete_highlighted"></mark>
+ <mark class="autoComplete_highlighted"></mark>
```