### PR TITLE
Move result item highlight styles to default class

### DIFF
--- a/dist/autoComplete.js
+++ b/dist/autoComplete.js
@@ -207,11 +207,13 @@
     return condition ? condition(query) : query.length >= threshold;
   };
   var mark = function mark(value, cls) {
+    if (cls === false) return;
+    var klass = {
+      "class": typeof cls === "string" ? cls : "default_hightlight"
+    };
     return create("mark", _objectSpread2({
       innerHTML: value
-    }, typeof cls === "string" && {
-      "class": cls
-    })).outerHTML;
+    }, klass)).outerHTML;
   };
 
   var configure = (function (ctx) {

--- a/dist/css/autoComplete.01.css
+++ b/dist/css/autoComplete.01.css
@@ -70,13 +70,13 @@
   background-color: rgba(123, 123, 123, 0.1);
 }
 
-.autoComplete_wrapper > ul > li mark {
+.autoComplete_wrapper .default_hightlight {
   background-color: transparent;
   color: rgba(255, 122, 122, 1);
   font-weight: bold;
 }
 
-.autoComplete_wrapper > ul > li mark::selection {
+.autoComplete_wrapper .default_hightlight::selection {
   color: rgba(#ffffff, 0);
   background-color: rgba(#ffffff, 0);
 }

--- a/dist/css/autoComplete.02.css
+++ b/dist/css/autoComplete.02.css
@@ -60,13 +60,13 @@
   background-color: rgba(123, 123, 123, 0.1);
 }
 
-.autoComplete_wrapper > ul > li mark {
+.autoComplete_wrapper .default_hightlight {
   background-color: transparent;
   color: rgba(255, 122, 122, 1);
   font-weight: bold;
 }
 
-.autoComplete_wrapper > ul > li mark::selection {
+.autoComplete_wrapper .default_hightlight::selection {
   color: rgba(#ffffff, 0);
   background-color: rgba(#ffffff, 0);
 }

--- a/dist/css/autoComplete.css
+++ b/dist/css/autoComplete.css
@@ -106,7 +106,7 @@
   transition: all 0.2s ease;
 }
 
-.autoComplete_wrapper > ul > li mark {
+.autoComplete_wrapper .default_hightlight {
   background-color: transparent;
   color: rgba(255, 122, 122, 1);
   font-weight: bold;

--- a/docs/demo/css/autoComplete.01.css
+++ b/docs/demo/css/autoComplete.01.css
@@ -70,13 +70,13 @@
   background-color: rgba(123, 123, 123, 0.1);
 }
 
-.autoComplete_wrapper > ul > li mark {
+.autoComplete_wrapper .default_hightlight {
   background-color: transparent;
   color: rgba(255, 122, 122, 1);
   font-weight: bold;
 }
 
-.autoComplete_wrapper > ul > li mark::selection {
+.autoComplete_wrapper .default_hightlight::selection {
   color: rgba(#ffffff, 0);
   background-color: rgba(#ffffff, 0);
 }

--- a/docs/demo/css/autoComplete.02.css
+++ b/docs/demo/css/autoComplete.02.css
@@ -60,13 +60,13 @@
   background-color: rgba(123, 123, 123, 0.1);
 }
 
-.autoComplete_wrapper > ul > li mark {
+.autoComplete_wrapper .default_hightlight {
   background-color: transparent;
   color: rgba(255, 122, 122, 1);
   font-weight: bold;
 }
 
-.autoComplete_wrapper > ul > li mark::selection {
+.autoComplete_wrapper .default_hightlight::selection {
   color: rgba(#ffffff, 0);
   background-color: rgba(#ffffff, 0);
 }

--- a/docs/demo/css/autoComplete.css
+++ b/docs/demo/css/autoComplete.css
@@ -106,7 +106,7 @@
   transition: all 0.2s ease;
 }
 
-.autoComplete_wrapper > ul > li mark {
+.autoComplete_wrapper .default_hightlight {
   background-color: transparent;
   color: rgba(255, 122, 122, 1);
   font-weight: bold;

--- a/docs/demo/js/autoComplete.js
+++ b/docs/demo/js/autoComplete.js
@@ -207,11 +207,13 @@
     return condition ? condition(query) : query.length >= threshold;
   };
   var mark = function mark(value, cls) {
+    if (cls === false) return;
+    var klass = {
+      "class": typeof cls === "string" ? cls : "default_hightlight"
+    };
     return create("mark", _objectSpread2({
       innerHTML: value
-    }, typeof cls === "string" && {
-      "class": cls
-    })).outerHTML;
+    }, klass)).outerHTML;
   };
 
   var configure = (function (ctx) {

--- a/src/helpers/io.js
+++ b/src/helpers/io.js
@@ -108,10 +108,16 @@ const checkTrigger = (query, condition, threshold) => (condition ? condition(que
  *
  * @returns {HTMLElement} - newly create html element
  */
-const mark = (value, cls) =>
-  create("mark", {
-    innerHTML: value,
-    ...(typeof cls === "string" && { class: cls }),
-  }).outerHTML;
+const mark = (value, cls) => {
+  if(cls === false) return
 
+  const klass = {
+    class: typeof cls === "string" ? cls : "default_hightlight"
+  }
+
+  return create("mark", {
+    innerHTML: value,
+    ...klass,
+  }).outerHTML;
+}
 export { select, create, getQuery, format, debounce, checkTrigger, mark };


### PR DESCRIPTION
Closes #264 

Currently, the highlight CSS rules are applied directly to the mark tag,
this causes that utility classes are not applied directly and you need
to define a specific class to override the design.

This change introduces a default_hightlight class to apply the library
colors to the component when no custom class is defined.


CodePen Before the change
https://codepen.io/JuanCrg90/pen/qBmKZZy

CodePen After the change
https://codepen.io/JuanCrg90/pen/gOWKGZP