### PR TITLE
Fix invalid use of rgba() with hex color codes

### DIFF
--- a/dist/css/autoComplete.01.css
+++ b/dist/css/autoComplete.01.css
@@ -61,8 +61,8 @@
 }
 
 .autoComplete_wrapper > ul > li::selection {
-  color: rgba(#ffffff, 0);
-  background-color: rgba(#ffffff, 0);
+  color: transparent
+  background-color: transparent
 }
 
 .autoComplete_wrapper > ul > li:hover {
@@ -77,8 +77,8 @@
 }
 
 .autoComplete_wrapper > ul > li mark::selection {
-  color: rgba(#ffffff, 0);
-  background-color: rgba(#ffffff, 0);
+  color: transparent
+  background-color: transparent
 }
 
 .autoComplete_wrapper > ul > li[aria-selected="true"] {

--- a/dist/css/autoComplete.02.css
+++ b/dist/css/autoComplete.02.css
@@ -51,8 +51,8 @@
 }
 
 .autoComplete_wrapper > ul > li::selection {
-  color: rgba(#ffffff, 0);
-  background-color: rgba(#ffffff, 0);
+  color: transparent
+  background-color: transparent
 }
 
 .autoComplete_wrapper > ul > li:hover {
@@ -67,8 +67,8 @@
 }
 
 .autoComplete_wrapper > ul > li mark::selection {
-  color: rgba(#ffffff, 0);
-  background-color: rgba(#ffffff, 0);
+  color: transparent
+  background-color: transparent
 }
 
 .autoComplete_wrapper > ul > li[aria-selected="true"] {


### PR DESCRIPTION
# Fix invalid use of rgba() with hex color codes

## Summary

This pull request replaces the incorrect usage of `rgba(#ffffff, 0)` with the proper `transparent` keyword.

## Details

The original code used the following CSS:

```css
color: rgba(#ffffff, 0);
background-color: rgba(#ffffff, 0);
```

This syntax is invalid in standard CSS. While some CSS preprocessors like Sass may allow similar shorthand forms, using `rgba()` with a hex code as the first argument is not supported in standard CSS and may cause parsing issues or errors in certain environments.

### Fix:

```css
color: transparent;
background-color: transparent;
```

The keyword `transparent` is equivalent to `rgba(0, 0, 0, 0)` and is the most readable and widely compatible way to apply full transparency.

## Benefits

- Improves compatibility with standard CSS parsers
- Avoids potential errors or misinterpretations in CSS tools
- Enhances readability and maintainability of the code

Thank you for your work on this project!
