### PR TITLE
Fix stale response race condition in async search

### DIFF
--- a/src/autoComplete.js
+++ b/src/autoComplete.js
@@ -63,6 +63,8 @@ export default function autoComplete(config) {
     maxResults: 5,
   };
   this.resultItem = { tag: "li" };
+  // Request ID counter to detect and discard stale async responses
+  this._requestId = 0;
   // Set all Configuration options
   configure(this);
   // Stage API methods

--- a/src/services/start.js
+++ b/src/services/start.js
@@ -17,8 +17,12 @@ export default async function (ctx, q) {
 
   // Validate trigger condition
   if (condition) {
+    // Track this request to detect stale responses
+    const requestId = ++ctx._requestId;
     // Get from source
     await getData(ctx, queryVal);
+    // Discard if a newer request has been made since this one started
+    if (ctx._requestId !== requestId) return;
     // Check if data fetch failed
     if (ctx.feedback instanceof Error) return;
     // Find matching results to the query


### PR DESCRIPTION
When a user types quickly, multiple async requests can be in-flight simultaneously. Previously, a slower request for an earlier query for example, a user typing "sea" quickly and continuing to "search" could see results for "sea" overwrite the correct results for "search".

### Changes:
- Added a _requestId counter to the autoComplete context that increments on each search invocation
- After await getData() resolves, the response is discarded if a newer request was made in the meantime